### PR TITLE
Feature: allow connection name for migrations table to be set in config

### DIFF
--- a/config/elastic.migrations.php
+++ b/config/elastic.migrations.php
@@ -2,6 +2,7 @@
 
 return [
     'table' => env('ELASTIC_MIGRATIONS_TABLE', 'elastic_migrations'),
+    'connection' => env('ELASTIC_MIGRATIONS_CONNECTION', ''),
     'storage_directory' => env('ELASTIC_MIGRATIONS_DIRECTORY', base_path('elastic/migrations')),
     'index_name_prefix' => env('ELASTIC_MIGRATIONS_INDEX_NAME_PREFIX', env('SCOUT_PREFIX', '')),
     'alias_name_prefix' => env('ELASTIC_MIGRATIONS_ALIAS_NAME_PREFIX', env('SCOUT_PREFIX', '')),

--- a/src/Repositories/MigrationRepository.php
+++ b/src/Repositories/MigrationRepository.php
@@ -15,10 +15,15 @@ final class MigrationRepository implements ReadinessInterface
      * @var string
      */
     private $table;
+    /**
+     * @var string
+     */
+    private $connection;
 
     public function __construct()
     {
         $this->table = config('elastic.migrations.table');
+        $this->connection = config('elastic.migrations.connection');
     }
 
     public function insert(string $fileName, int $batch): bool
@@ -71,11 +76,11 @@ final class MigrationRepository implements ReadinessInterface
 
     private function table(): Builder
     {
-        return DB::table($this->table);
+        return DB::connection($this->connection)->table($this->table);
     }
 
     public function isReady(): bool
     {
-        return Schema::hasTable($this->table);
+        return Schema::connection($this->connection)->hasTable($this->table);
     }
 }


### PR DESCRIPTION
A small change that allows configuration of the connection name for the migrations table. 
Default is set to '' → current behaviour.

Let me know if I need to add more or more info is needed. Wasn't sure if tests would be really beneficial given its basic Laravel functionality. Anyway I've tested it manually in my app to be sure I didn't forget anything :)