### PR TITLE
Add ability to add directories to MigrationStorage

### DIFF
--- a/src/Filesystem/MigrationStorage.php
+++ b/src/Filesystem/MigrationStorage.php
@@ -15,21 +15,31 @@ class MigrationStorage implements ReadinessInterface
     /**
      * @var string
      */
-    private $directory;
+    private $mainDirectory;
+    /**
+     * @var array
+     */
+    private $directories = [];
 
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
-        $this->directory = rtrim(config('elastic.migrations.storage_directory', ''), '/');
+        $this->mainDirectory = rtrim(config('elastic.migrations.storage_directory', ''), '/');
+        $this->directories[] = $this->mainDirectory;
+    }
+
+    public function addDirectory(string $directory): void
+    {
+        $this->directories = array_unique(array_merge($this->directories, [$directory]));
     }
 
     public function create(string $fileName, string $content): MigrationFile
     {
-        if (!$this->filesystem->isDirectory($this->directory)) {
-            $this->filesystem->makeDirectory($this->directory, 0755, true);
+        if (!$this->filesystem->isDirectory($this->mainDirectory)) {
+            $this->filesystem->makeDirectory($this->mainDirectory, 0755, true);
         }
 
-        $filePath = $this->resolvePath($fileName);
+        $filePath = $this->resolvePath($fileName, $this->mainDirectory);
         $this->filesystem->put($filePath, $content);
 
         return new MigrationFile($filePath);
@@ -37,27 +47,37 @@ class MigrationStorage implements ReadinessInterface
 
     public function findByName(string $fileName): ?MigrationFile
     {
-        $filePath = $this->resolvePath($fileName);
+        foreach($this->directories as $directory) {
+            $filePath = $this->resolvePath($fileName, $directory);
 
-        return $this->filesystem->exists($filePath) ? new MigrationFile($filePath) : null;
+            if ($this->filesystem->exists($filePath)) {
+                return new MigrationFile($filePath);
+            }
+        }
+
+        return null;
     }
 
     public function findAll(): Collection
     {
-        $files = $this->filesystem->glob($this->directory . '/*_*.php');
+        $files = [];
+        foreach ($this->directories as $directory) {
+            $files[] = $this->filesystem->glob($directory . '/*_*.php');
+        }
+        $files = array_merge([], ...$files);
 
-        return collect($files)->sort()->map(static function (string $filePath) {
+        return collect($files)->sort()->values()->map(static function (string $filePath) {
             return new MigrationFile($filePath);
         });
     }
 
-    private function resolvePath(string $fileName): string
+    private function resolvePath(string $fileName, string $directory): string
     {
-        return sprintf('%s/%s.php', $this->directory, str_replace('.php', '', trim($fileName)));
+        return sprintf('%s/%s.php', $directory, str_replace('.php', '', trim($fileName)));
     }
 
     public function isReady(): bool
     {
-        return $this->filesystem->isDirectory($this->directory);
+        return $this->filesystem->isDirectory($this->mainDirectory);
     }
 }

--- a/tests/another_migrations/2018_12_01_900000_create_another_test_index.php
+++ b/tests/another_migrations/2018_12_01_900000_create_another_test_index.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+use ElasticMigrations\Facades\Index;
+use ElasticMigrations\MigrationInterface;
+use Elasticsearch\Client;
+
+final class CreateAnotherTestIndex implements MigrationInterface
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function up(): void
+    {
+        Index::create('another_test');
+
+        $this->client->indices()->clearCache([
+            'index' => 'another_test',
+        ]);
+    }
+
+    public function down(): void
+    {
+        Index::drop('another_test');
+    }
+}

--- a/tests/another_migrations/2019_08_10_159130_update_another_test_index_mapping.php
+++ b/tests/another_migrations/2019_08_10_159130_update_another_test_index_mapping.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+use ElasticAdapter\Indices\Mapping;
+use ElasticMigrations\Facades\Index;
+use ElasticMigrations\MigrationInterface;
+
+final class UpdateAnotherTestIndexMapping implements MigrationInterface
+{
+    public function up(): void
+    {
+        Index::putMapping('another_test', static function (Mapping $mapping) {
+            $mapping->enableSource();
+            $mapping->text('title');
+        });
+    }
+
+    public function down(): void
+    {
+        Index::putMapping('another_test', static function (Mapping $mapping) {
+            $mapping->disableSource();
+        });
+    }
+}


### PR DESCRIPTION
This PR adds the ability to add directories to MigrationStorage.
Using the addDirectory function, we can add additional directories for MigrationStorage.
This way we can define a function to register additional directories in the ServiceProvider (like `loadMigrationsFrom` to register database migrations).

For example:
```
/**
 * Register elastic migration directories.
 *
 * @param  array|string  $directories
 * @return void
 */
protected function loadElasticMigrationsFrom($directories)
{
    $this->callAfterResolving(\ElasticMigrations\Filesystem\MigrationStorage::class, function ($migrationStorage) use ($directories) {
        foreach ((array) $directories as $directory) {
            $migrationStorage->addDirectory($directory);
        }
    });
}
```