### PR TITLE
Use `delete()` instead of `truncate()` in Migration Repository

### DIFF
--- a/src/Console/FreshCommand.php
+++ b/src/Console/FreshCommand.php
@@ -35,7 +35,7 @@ class FreshCommand extends Command
 
         $indexManager->drop('*');
 
-        $migrationRepository->truncate();
+        $migrationRepository->deleteAll();
 
         $migrator->migrateAll();
 

--- a/src/Repositories/MigrationRepository.php
+++ b/src/Repositories/MigrationRepository.php
@@ -50,7 +50,7 @@ class MigrationRepository implements ReadinessInterface
 
     public function truncate(): void
     {
-        $this->table()->truncate();
+        $this->table()->delete();
     }
 
     public function getLastBatchNumber(): ?int

--- a/src/Repositories/MigrationRepository.php
+++ b/src/Repositories/MigrationRepository.php
@@ -58,7 +58,7 @@ class MigrationRepository implements ReadinessInterface
      */
     public function truncate(): void
     {
-        $this->deleteAll();
+        $this->table()->truncate();
     }
 
     public function getLastBatchNumber(): ?int

--- a/src/Repositories/MigrationRepository.php
+++ b/src/Repositories/MigrationRepository.php
@@ -48,9 +48,17 @@ class MigrationRepository implements ReadinessInterface
             ->delete();
     }
 
-    public function truncate(): void
+    public function deleteAll(): void
     {
         $this->table()->delete();
+    }
+
+    /**
+     * @deprecated
+     */
+    public function truncate(): void
+    {
+        $this->deleteAll();
     }
 
     public function getLastBatchNumber(): ?int

--- a/tests/Integration/Console/FreshCommandTest.php
+++ b/tests/Integration/Console/FreshCommandTest.php
@@ -63,7 +63,7 @@ final class FreshCommandTest extends TestCase
 
         $this->migrationRepository
             ->expects($this->never())
-            ->method('truncate');
+            ->method('deleteAll');
 
         $this->migrator
             ->expects($this->never())
@@ -91,7 +91,7 @@ final class FreshCommandTest extends TestCase
 
         $this->migrationRepository
             ->expects($this->once())
-            ->method('truncate');
+            ->method('deleteAll');
 
         $this->migrator
             ->expects($this->once())

--- a/tests/Integration/Repositories/MigrationRepositoryTest.php
+++ b/tests/Integration/Repositories/MigrationRepositoryTest.php
@@ -106,11 +106,11 @@ final class MigrationRepositoryTest extends TestCase
         $this->assertFalse($this->migrationRepository->isReady());
     }
 
-    public function test_repository_can_truncate_all_records(): void
+    public function test_repository_can_delete_all_records(): void
     {
         $this->assertCount(2, $this->migrationRepository->getAll());
 
-        $this->migrationRepository->truncate();
+        $this->migrationRepository->deleteAll();
 
         $this->assertCount(0, $this->migrationRepository->getAll());
     }

--- a/tests/Integration/Repositories/MigrationRepositoryTest.php
+++ b/tests/Integration/Repositories/MigrationRepositoryTest.php
@@ -105,4 +105,13 @@ final class MigrationRepositoryTest extends TestCase
 
         $this->assertFalse($this->migrationRepository->isReady());
     }
+
+    public function test_repository_can_truncate_all_records(): void
+    {
+        $this->assertDatabaseCount($this->table, 2);
+
+        $this->migrationRepository->truncate();
+
+        $this->assertDatabaseCount($this->table, 0);
+    }
 }

--- a/tests/Integration/Repositories/MigrationRepositoryTest.php
+++ b/tests/Integration/Repositories/MigrationRepositoryTest.php
@@ -108,10 +108,10 @@ final class MigrationRepositoryTest extends TestCase
 
     public function test_repository_can_truncate_all_records(): void
     {
-        $this->assertDatabaseCount($this->table, 2);
+        $this->assertCount(2, $this->migrationRepository->getAll());
 
         $this->migrationRepository->truncate();
 
-        $this->assertDatabaseCount($this->table, 0);
+        $this->assertCount(0, $this->migrationRepository->getAll());
     }
 }


### PR DESCRIPTION
Closes https://github.com/babenkoivan/elastic-migrations/issues/34

Unfortunately I'm not able to emulate the database transaction closing with SQLite upon `truncate()` (SQLite will execute a `DELETE` statement since it apparently does not support truncates).

I did however add a sanity test so we're sure all records are actually deleted with `delete()`.

If you'd like me to scaffold a GitHub test action with a MySQL instance to run the tests on let me know! 👍 