### PR TITLE
Delete indices one by one

### DIFF
--- a/src/Console/FreshCommand.php
+++ b/src/Console/FreshCommand.php
@@ -33,7 +33,9 @@ class FreshCommand extends Command
             return 1;
         }
 
-        $indexManager->drop('*');
+        foreach ($indexManager->all() as $index) {
+            $indexManager->delete($index['index']);
+        }
 
         $migrationRepository->deleteAll();
 


### PR DESCRIPTION
As of ElasticSearch 8.*, deleting indices using wildcard or `_all` queries is disabled by default:

> By default, this parameter does not support wildcards (*) or _all. To use wildcards or _all, set the action.destructive_requires_name cluster setting to false.
https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-delete-index.html

Therefore it would be a better way, to delete all indices one by one.

This PR uses the `$indexManager->all()` method of the following PR in `elastic-adapter`:
https://github.com/babenkoivan/elastic-adapter/pull/24

Original Bug Report: https://github.com/babenkoivan/elastic-migrations/issues/38