### PR TITLE
Add primary key to elastic migrations table

### DIFF
--- a/database/migrations/2019_15_12_112000_create_elastic_migrations_table.php
+++ b/database/migrations/2019_15_12_112000_create_elastic_migrations_table.php
@@ -16,6 +16,7 @@ class CreateElasticMigrationsTable extends Migration
     public function up(): void
     {
         Schema::create($this->table, static function (Blueprint $table) {
+            $table->id();
             $table->string('migration');
             $table->integer('batch');
         });


### PR DESCRIPTION
Currently the table that keeps track of the already migrated Elastic migrations has no primary key defined in the schema.
This can be required in MySQL through `sql_require_primary_key` and is not always configurable by the end user (e.g. DigitalOcean enforces this on their managed database solution).

This PR adds a primary key to that table so the table can be created.
