### PR TITLE
Update base migration file to check if table elastic_migrations table already exists

### DIFF
--- a/database/migrations/2019_15_12_112000_create_elastic_migrations_table.php
+++ b/database/migrations/2019_15_12_112000_create_elastic_migrations_table.php
@@ -15,10 +15,12 @@ class CreateElasticMigrationsTable extends Migration
 
     public function up(): void
     {
-        Schema::create($this->table, static function (Blueprint $table) {
-            $table->string('migration')->primary();
-            $table->integer('batch');
-        });
+        if (!Schema::hasTable($this->table)) {
+            Schema::create($this->table, static function (Blueprint $table) {
+                $table->string('migration')->primary();
+                $table->integer('batch');
+            });
+        }
     }
 
     public function down(): void


### PR DESCRIPTION
Currently the base schema migration assumes that the `elastic_migrations` table does not exist.

This is problematic when restoring a schema from a schema:dump with prune: `php artisan schema:dump --prune`

When you run `php artisan migrate`, Laravel restores the schema dump in database/schema which recreates tables like `elastic_migrations`.

It follows that the `migrations` table exists and is empty. Additionally, the `elastic_migrations` table exists and is empty. 

Therefore, if you try to create and run a new migration, this library sees that `2019_15_12_112000_create_elastic_migrations_table.php` does not exist in the migrations table and tries to create the `elastic_migrations` table. This causes an error because the table actually does exist. This is the error that is thrown:

```
SQLSTATE[42P07]: Duplicate table: 7 ERROR:  relation "elastic_migrations" already exists (SQL: create table "elastic_migrations" ("migration" varchar(255) not null, "batch" integer not null))
```