### PR TITLE
Fix implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/Adapters/IndexManagerAdapter.php
+++ b/src/Adapters/IndexManagerAdapter.php
@@ -157,7 +157,7 @@ class IndexManagerAdapter implements IndexManagerInterface
         return $this;
     }
 
-    public function putAlias(string $indexName, string $aliasName, array $settings = null): IndexManagerInterface
+    public function putAlias(string $indexName, string $aliasName, ?array $settings = null): IndexManagerInterface
     {
         $prefixedIndexName = prefix_index_name($indexName);
         $prefixedAliasName = prefix_alias_name($aliasName);


### PR DESCRIPTION
See: <https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated>

use [rector](https://github.com/rectorphp/rector) auto fix:

rules:

- ExplicitNullableParamTypeRector