### PR TITLE
Fix implicitly nullable parameter declarations in PHP 8.4

### DIFF
--- a/src/Adapters/IndexManagerAdapter.php
+++ b/src/Adapters/IndexManagerAdapter.php
@@ -161,7 +161,7 @@ class IndexManagerAdapter implements IndexManagerInterface
         return $this;
     }
 
-    public function putAlias(string $indexName, string $aliasName, array $filter = null): IndexManagerInterface
+    public function putAlias(string $indexName, string $aliasName, ?array $filter = null): IndexManagerInterface
     {
         $prefixedIndexName = prefix_index_name($indexName);
         $prefixedAliasName = prefix_alias_name($aliasName);


### PR DESCRIPTION
Could you please create a `v2` branch?